### PR TITLE
Typo fixes, clarification edits

### DIFF
--- a/metagenomics-workshop-activity.md
+++ b/metagenomics-workshop-activity.md
@@ -41,7 +41,7 @@ bash install.sh
 Follow instructions, and execute the command shown.
 
 ```{bash}
-echo "export PATH=$PATH:/home/kylebittinger/miniconda3/bin" >> ~/.bashrc
+echo "export PATH=$PATH:~/miniconda3/bin" >> ~/.bashrc
 ```
 
 Following the instructions, close and re-open the terminal window.

--- a/metagenomics-workshop-activity.md
+++ b/metagenomics-workshop-activity.md
@@ -7,10 +7,10 @@ very similar on Amazon's service, or on another cloud computing provider.
 Google provides new users with a substantial credit towards computing costs,
 and allows us to launch a terminal window conveniently from the web browser.
 
-We will request a computer with 8 CPU cores and 52 GB of memory.  We'll ask
+We will request a VM instance with 8 CPU cores and 52 GB of memory.  We'll ask
 for 100 GB of hard drive space.  The operating system will be Ubuntu Linux
 18.04 LTS.  This is a typical Linux system, with no special bioinformatics
-software installed.
+software installed. (Make sure you don't select the "Minimal" version.)
 
 We will install all the software we need in your home directory using a system
 called Conda. This approach requires no administrative priveleges, so you
@@ -22,6 +22,9 @@ a report.
 
 These steps are copy/pasted from the Sunbeam documentation at
 http://sunbeam.readthedocs.io/en/latest/quickstart.html
+
+To open a terminal window in your browser, select the "Open in browser window" 
+option under the "Connect" column on your Google Cloud VM instances page.
 
 ```{bash}
 cd ~

--- a/metagenomics-workshop-activity.md
+++ b/metagenomics-workshop-activity.md
@@ -24,7 +24,8 @@ These steps are copy/pasted from the Sunbeam documentation at
 http://sunbeam.readthedocs.io/en/latest/quickstart.html
 
 To open a terminal window in your browser, select the "Open in browser window" 
-option under the "Connect" column on your Google Cloud VM instances page.
+option under the "Connect" column on your Google Cloud VM instances page. 
+Execute the following commands:
 
 ```{bash}
 cd ~
@@ -113,7 +114,8 @@ We need two reference databases to run this sample: a database of host DNA
 sequence to remove, and a database of bacterial DNA to match against.
 
 We'll get the human genome data from UCSC.  Filtering against the entire human
-genome takes too long, so we'll only filter against chromosome 1.
+genome takes too long, so we'll only filter against chromosome 1. The following
+commands download and unzip the .fasta file for chromosome 1:
 
 ```{bash}
 cd ~

--- a/metagenomics-workshop-activity.md
+++ b/metagenomics-workshop-activity.md
@@ -94,7 +94,7 @@ ls
 Explore the samples file.
 
 ```{bash}
-nano sunbeam_config.yml
+nano samples.csv
 ```
 
 Explore the configuration file.

--- a/metagenomics-workshop-activity.md
+++ b/metagenomics-workshop-activity.md
@@ -69,13 +69,13 @@ Semi-Elemental Diet and Stool Microbiome), which was conducted at Penn and CHOP.
 cd ~
 mkdir workshop-data
 cd workshop-data
-fasterq-dump SRR2145310
-fasterq-dump SRR2145329
-fasterq-dump SRR2145381
-fasterq-dump SRR2145353
-fasterq-dump SRR2145354
-fasterq-dump SRR2145492
-fasterq-dump SRR2145498
+fasterq-dump SRR2145310 -e 8
+fasterq-dump SRR2145329 -e 8
+fasterq-dump SRR2145381 -e 8
+fasterq-dump SRR2145353 -e 8
+fasterq-dump SRR2145354 -e 8
+fasterq-dump SRR2145492 -e 8
+fasterq-dump SRR2145498 -e 8
 ```
 
 First mini-lecture.


### PR DESCRIPTION
This pull request fixes a few typos: one in the export command (replacing `/home/kylebittinger` with `~`), and one in the line referring to the sample sheet, which should be `samples.csv`. I've also suggested a few additions for clarification or more detail based on my running through the instructions this morning, and things that I thought might be useful for people who are new to this sort of thing.

Other thoughts of things to include:

  - The only thing I usually do with a new Sunbeam install that isn't in the instruction list is run the tests (`tests/run_tests.bash -e sunbeam`). You may not want to do this for the sake of time, but I just wanted to mention it in case.
  - Usually before a Sunbeam run I do a dry run (`-n`)--might be a nice way for the students to get an overview of what Sunbeam is actually gonna do.